### PR TITLE
Update README to include more elaborate instructions on use of bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Then exit the package mode with 🔙 or Ctrl + c
 julia> using PreCICE
 ```
 
-Once the package is added you can directly access preCICE API commands in the Julia environment, for example `getVersionInformation()`. Alternative to the environment you can also inclue the package in your Julia script in the following way:
+Once the package is added you can directly access preCICE API commands in the Julia environment, for example `getVersionInformation()`. Alternative to the environment you can also include the package in your Julia script in the following way:
 
 ```julia
 import Pkg; Pkg.add(url="https://github.com/precice/julia-bindings.git")

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ You can use the Julia bindings for preCICE can be used by adding them as a packa
 
 ```julia
 julia> ]
-pkg> add https://github.com/precice/julia-bindings.git
+pkg> add https://github.com/precice/julia-bindings.git 
+Then exit the package mode with 🔙 or Ctrl + c
 julia> using PreCICE
 ```
 
@@ -32,4 +33,19 @@ By default this package assumes the `libprecice.so` is at `/usr/lib/x86_64-linux
 
 # Usage
 You can look at [solverdummy](https://github.com/precice/julia-bindings/tree/main/solverdummy) as an example of how to use the Julia bindings for preCICE
+
+
+# Testing new features that are on branches of this repository
+
+To use a certain branch of this package, add `#branchname` after the package url, example downloading the `mpi-parallelization` branch:
+
+
+```julia
+julia> ]
+pkg> add https://github.com/precice/julia-bindings.git#mpi-parallelization
+Then exit the package mode with 🔙 or Ctrl + c
+julia> using PreCICE
+```
+
+
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ julia> using PreCICE
 
 # Dependencies
 
-This package works with official Julia binaries. See the [Platform Specific Instructions for official Binaries](https://julialang.org/downloads/platform/)  or [Julia's documentation](https://docs.julialang.org/en/v1/manual/getting-started/) if you are not sure how to download them.
+This package works with official Julia binaries listed below. See the [Platform Specific Instructions for official Binaries](https://julialang.org/downloads/platform/)  or [Julia's documentation](https://docs.julialang.org/en/v1/manual/getting-started/) if you are not sure how to download them.
+
+## Supported versions:
+
+`1.6` and newer
 
 [Unofficial Julia binaries](https://julialang.org/downloads/platform/#platform_specific_instructions_for_unofficial_binaries) may not be compatible.
 

--- a/README.md
+++ b/README.md
@@ -47,5 +47,9 @@ Then exit the package mode with 🔙 or Ctrl + c
 julia> using PreCICE
 ```
 
+# Dependencies
 
+This package works with official Julia binaries. See the [Platform Specific Instructions for official Binaries](https://julialang.org/downloads/platform/)  or [Julia's documentation](https://docs.julialang.org/en/v1/manual/getting-started/) if you are not sure how to download them.
+
+[Unofficial Julia binaries](https://julialang.org/downloads/platform/#platform_specific_instructions_for_unofficial_binaries) may not be compatible.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 This package provides Julia language bindings for the C++ library [preCICE](https://github.com/precice/precice). It is a Julia package that wraps the API of preCICE.
 
+## Adding the package to a Julia environment or script
 
-# Adding the package to a Julia environment or script
-You can use the Julia bindings for preCICE can be used by adding them as a package in a Julia environment or also directly including the package in a Julia script. For both usages you need to have preCICE installed on the system. For preCICE installation you can look at the [installation documentation](https://precice.org/installation-overview.html). You can directly add the Julia bindings to your Julia environment in the following way:
+You can use the Julia bindings for preCICE by adding them as a package in a Julia environment or also directly including the package in a Julia script. For both usages you need to have preCICE installed on the system. For preCICE installation you can look at the [installation documentation](https://precice.org/installation-overview.html). You can directly add the Julia bindings to your Julia environment in the following way:
 
 ```julia
 julia> ]
@@ -17,7 +17,7 @@ Then exit the package mode with 🔙 or Ctrl + c
 julia> using PreCICE
 ```
 
-Once the package is added you can directly access preCICE API commands in the Julia environment, for example `getVersionInformation()`. Alternative to the environment you can also include the package in your Julia script in the following way:
+Once the package is added you can directly access preCICE API commands in the Julia environment, for example `getVersionInformation()`. Alternatively you can also include the package in your Julia script in the following way:
 
 ```julia
 import Pkg; Pkg.add(url="https://github.com/precice/julia-bindings.git")
@@ -26,19 +26,19 @@ using PreCICE
 
 Once the package is added at the beginning of the Julia script you can access the preCICE API commands in the script.
 
-## Adding when preCICE is installed at custom paths
-If you installed preCICE at a custom path, errors like ```ERROR: could not load library "/..."``` can be seen after adding the Julia bindings package. In such cases set the path to your library with `PreCICE.setPathToLibprecice("path/to/my/libprecice.so")` or reset it with `PreCICE.resetPathToLibprecice()`
+## Adding the package when preCICE is installed at custom paths
+
+If you installed preCICE at a custom path, errors like ```ERROR: could not load library "/..."``` can occur after adding the Julia bindings package. In such cases set the path to your library with `PreCICE.setPathToLibprecice("path/to/my/libprecice.so")` or reset it with `PreCICE.resetPathToLibprecice()`
 
 By default this package assumes the `libprecice.so` is at `/usr/lib/x86_64-linux-gnu/`.
 
-# Usage
-You can look at [solverdummy](https://github.com/precice/julia-bindings/tree/main/solverdummy) as an example of how to use the Julia bindings for preCICE
+## Usage
 
+You can look at [solverdummy](https://github.com/precice/julia-bindings/tree/main/solverdummy) as an example of how to use the Julia bindings for preCICE.
 
-# Testing new features that are on branches of this repository
+## Testing new features that are on branches of this repository
 
-To use a certain branch of this package, add `#branchname` after the package url, example downloading the `mpi-parallelization` branch:
-
+To use a certain branch of this package, add `#branchname` after the package url, for example if the branch `mpi-parallelization` is to be tested:
 
 ```julia
 julia> ]
@@ -47,13 +47,12 @@ Then exit the package mode with 🔙 or Ctrl + c
 julia> using PreCICE
 ```
 
-# Dependencies
+## Dependencies
 
 This package works with official Julia binaries listed below. See the [Platform Specific Instructions for official Binaries](https://julialang.org/downloads/platform/)  or [Julia's documentation](https://docs.julialang.org/en/v1/manual/getting-started/) if you are not sure how to download them.
 
-## Supported versions:
+## Supported versions
 
 `1.6` and newer
 
 [Unofficial Julia binaries](https://julialang.org/downloads/platform/#platform_specific_instructions_for_unofficial_binaries) may not be compatible.
-


### PR DESCRIPTION
Closes https://github.com/precice/julia-bindings/issues/4

@pavelkharitenko lets also add a *Dependencies* section via this PR to the README where we explain Julia installation and which versions are compatible with the bindings.