### PR TITLE
Enable custom precice path

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,6 @@
 
 # check if environmental variable is set and is a real path, if not throw error
+using PreCICE
 
 libprecicePath = split(readlines(`whereis libprecice`)[], ' ')[2]
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,10 @@
 
 # check if environmental variable is set and is a real path, if not throw error
 
+libprecicePath = split(readlines(`whereis libprecice`)[], ' ')[2]
+
+PreCICE.setPathToLibprecice(string(libprecicePath))
+
 
 if haskey(ENV, "PRECICE_JL_BINARY")
     libprecicePath = ENV["PRECICE_JL_BINARY"]

--- a/src/PreCICE.jl
+++ b/src/PreCICE.jl
@@ -13,8 +13,8 @@ The `PreCICE` module provides the bindings for using the preCICE api. For more i
 # TODO createSolverInterfaceWithCommunicator documentation
 # TODO does it make sense to set the data_id by hand in the example
 
-libprecicePath = "/usr/lib/x86_64-linux-gnu/libprecice.so"
-defaultLibprecicePath = "/usr/lib/x86_64-linux-gnu/libprecice.so"
+libprecicePath = "/usr/local/lib/libprecice.so"
+defaultLibprecicePath = "/usr/local/lib/libprecice.so"
 
 
 export 
@@ -54,7 +54,7 @@ end
 
 
 @doc """
-Reset custom path configurations and use the binary at the default path "/usr/lib/x86_64-linux-gnu/libprecice.so".
+Reset custom path configurations and use the binary at the default path "/usr/local/lib/libprecice.so".
 """
 function resetPathToLibprecice() 
 global libprecicePath = defaultLibprecicePath

--- a/src/PreCICE.jl
+++ b/src/PreCICE.jl
@@ -13,6 +13,9 @@ The `PreCICE` module provides the bindings for using the preCICE api. For more i
 # TODO createSolverInterfaceWithCommunicator documentation
 # TODO does it make sense to set the data_id by hand in the example
 
+libprecicePath = "/usr/lib/x86_64-linux-gnu/libprecice.so"
+defaultLibprecicePath = "/usr/lib/x86_64-linux-gnu/libprecice.so"
+
 
 export 
     # construction and configuration
@@ -41,6 +44,25 @@ export
 
 @doc """
 
+setPathToLibprecice(pathToPrecice::String) 
+
+Configure which preCICE binary to use. Set it if preCICE was installed at a custom directory.
+"""
+function setPathToLibprecice(pathToPrecice::String) 
+global libprecicePath = pathToPrecice
+end
+
+
+@doc """
+Reset custom path configurations and use the binary at the default path "/usr/lib/x86_64-linux-gnu/libprecice.so".
+"""
+function resetPathToLibprecice() 
+global libprecicePath = defaultLibprecicePath
+end
+
+
+@doc """
+
     createSolverInterface(participantName::String, configFilename::String, solverProcessIndex::Integer, solverProcessSize::Integer)
 
 Create the coupling interface and configure it. Must get called before any other method of this interface.
@@ -60,7 +82,7 @@ function createSolverInterface(participantName::String,
                                 configFilename::String,   
                                 solverProcessIndex::Integer,  
                                 solverProcessSize::Integer)
-    ccall((:precicec_createSolverInterface, "libprecice"), 
+    ccall((:precicec_createSolverInterface, libprecicePath), 
             Cvoid, 
             (Ptr{Int8},Ptr{Int8}, Cint, Cint), 
             participantName, 
@@ -75,7 +97,7 @@ function createSolverInterfaceWithCommunicator(participantName::String,
                                                 solverProcessIndex::Integer,  
                                                 solverProcessSize::Integer, 
                                                 communicator::Union{Ptr{Cvoid}, Ref{Cvoid}, Ptr{Nothing}}) # test if type of com is correct
-    ccall((:precicec_createSolverInterface_withCommunicator, "libprecice"), 
+    ccall((:precicec_createSolverInterface_withCommunicator, libprecicePath), 
             Cvoid, 
             (Ptr{Int8}, Ptr{Int8}, Int, Int, Union{Ptr{Cvoid}, Ref{Cvoid}, Ptr{Nothing}}), 
             participantName, 
@@ -98,7 +120,7 @@ This function handles:
 Return the maximum length of first timestep to be computed by the solver.
 """
 function initialize()::Float64
-    dt::Float64 = ccall((:precicec_initialize, "libprecice"), Cdouble, ())
+    dt::Float64 = ccall((:precicec_initialize, libprecicePath), Cdouble, ())
     return dt
 end
 
@@ -131,7 +153,7 @@ Tasks completed:
  - Initial coupling data was exchanged.
 """
 function initializeData()
-    ccall((:precicec_initialize_data, "libprecice"), Cvoid, ())
+    ccall((:precicec_initialize_data, libprecicePath), Cvoid, ())
 end
 
 
@@ -163,7 +185,7 @@ Tasks completed:
  - Meshes with data are exported to files if configured.
 """
 function advance(computedTimestepLength::Float64)::Float64
-    dt::Float64 = ccall((:precicec_advance, "libprecice"), Cdouble, (Cdouble,), computedTimestepLength)
+    dt::Float64 = ccall((:precicec_advance, libprecicePath), Cdouble, (Cdouble,), computedTimestepLength)
     return dt
 end
 
@@ -184,7 +206,7 @@ Tasks completed:
  - Meshes and data are deallocated.
 """
 function finalize()
-    ccall((:precicec_finalize, "libprecice"), Cvoid, ())
+    ccall((:precicec_finalize, libprecicePath), Cvoid, ())
 end
 
 
@@ -197,7 +219,7 @@ can be solved using preCICE. The dimension is specified in the XML configuration
 """
 function getDimensions()::Integer
 
-    dim::Integer = ccall((:precicec_getDimensions, "libprecice"), Cint, ())
+    dim::Integer = ccall((:precicec_getDimensions, libprecicePath), Cint, ())
     return dim
 end
 
@@ -221,7 +243,7 @@ Previous calls:
  - [`initialize`](@ref) has been called successfully.
 """
 function isCouplingOngoing()::Bool
-    ans::Integer = ccall((:precicec_isCouplingOngoing, "libprecice"), Cint, ())
+    ans::Integer = ccall((:precicec_isCouplingOngoing, libprecicePath), Cint, ())
     return ans
 end
 
@@ -244,7 +266,7 @@ Previous calls:
 
 """
 function isTimeWindowComplete()::Bool
-    ans::Integer = ccall((:precicec_isTimeWindowComplete, "libprecice"), Cint, ())
+    ans::Integer = ccall((:precicec_isTimeWindowComplete, libprecicePath), Cint, ())
     return ans
 end
 
@@ -259,7 +281,7 @@ The solver may still have to evaluate the fine model representation.
 DEPRECATED: Only necessary for deprecated manifold mapping.
 """
 function hasToEvaluateSurrogateModel()::Bool
-    ans::Integer = ccall((:precicec_hasToEvaluateSurrogateModel, "libprecice"), Cint, ())
+    ans::Integer = ccall((:precicec_hasToEvaluateSurrogateModel, libprecicePath), Cint, ())
     return ans
 end
 
@@ -275,7 +297,7 @@ DEPRECATED: Only necessary for deprecated manifold mapping.
 Return whether the solver has to evaluate the fine model representation.
 """
 function hasToEvaluateFineModel()::Bool
-    ans::Integer = ccall((:precicec_hasToEvaluateFineModel, "libprecice"), Cint, ())
+    ans::Integer = ccall((:precicec_hasToEvaluateFineModel, libprecicePath), Cint, ())
     return ans
 end
 
@@ -297,7 +319,7 @@ Previous calls:
  - [`initialize`](@ref) has been called successfully.
 """
 function isReadDataAvailable()::Bool
-    ans::Integer = ccall((:precicec_isReadDataAvailable, "libprecice"), Cint, ())
+    ans::Integer = ccall((:precicec_isReadDataAvailable, libprecicePath), Cint, ())
     return ans
 end
 
@@ -325,7 +347,7 @@ Previous calls:
  - [`initialize`](@ref) has been called successfully.
 """
 function isWriteDataRequired(computedTimestepLength::Float64)::Bool
-    ans::Integer = ccall((:precicec_isWriteDataRequired, "libprecice"), Cint, (Cdouble,), computedTimestepLength)
+    ans::Integer = ccall((:precicec_isWriteDataRequired, libprecicePath), Cint, (Cdouble,), computedTimestepLength)
     return ans
 end
 
@@ -346,7 +368,7 @@ to signalize preCICE the correct behavior of the solver.
 
 """
 function isActionRequired(action::String)::Bool
-    ans::Integer = ccall((:precicec_isActionRequired, "libprecice"), Cint, (Ptr{Int8},), action)
+    ans::Integer = ccall((:precicec_isActionRequired, libprecicePath), Cint, (Ptr{Int8},), action)
     return ans
 end
 
@@ -366,7 +388,7 @@ Previous calls:
  - The solver fulfilled the specified action.
 """
 function markActionFulfilled(action::String)
-    ccall((:precicec_markActionFulfilled, "libprecice"), Cvoid, (Ptr{Int8},), action)
+    ccall((:precicec_markActionFulfilled, libprecicePath), Cvoid, (Ptr{Int8},), action)
 end
 
 
@@ -377,7 +399,7 @@ end
 Check if the mesh with given name is used by a solver. 
 """
 function hasMesh(meshName::String)::Bool
-    ans::Integer = ccall((:precicec_hasMesh, "libprecice"), Cint, (Ptr{Int8},), meshName)
+    ans::Integer = ccall((:precicec_hasMesh, libprecicePath), Cint, (Ptr{Int8},), meshName)
     return ans
 end
 
@@ -395,7 +417,7 @@ meshid = getMeshID("MeshOne")
 ```
 """
 function getMeshID(meshName::String)
-    ans::Integer = ccall((:precicec_getMeshID, "libprecice"), Cint, (Ptr{Int8},), meshName)
+    ans::Integer = ccall((:precicec_getMeshID, libprecicePath), Cint, (Ptr{Int8},), meshName)
     return ans
 end
 
@@ -413,7 +435,7 @@ Return true if the mesh is already used.
 
 """
 function hasData(dataName::String, meshID::Integer)::Bool
-    ans::Integer = ccall((:precicec_hasData, "libprecice"), Cint, (Ptr{Int8}, Cint), dataName, meshID)
+    ans::Integer = ccall((:precicec_hasData, libprecicePath), Cint, (Ptr{Int8}, Cint), dataName, meshID)
     return ans
 end
 
@@ -431,7 +453,7 @@ Return the data id belonging to the given name.
 The given name (`dataName`) has to be one of the names specified in the configuration file. The data ID obtained can be used to read and write data to and from the coupling mesh.
 """
 function getDataID(dataName::String, meshID::Integer)
-    id::Integer = ccall((:precicec_getDataID, "libprecice"), Cint, (Ptr{Int8}, Cint), dataName, meshID)
+    id::Integer = ccall((:precicec_getDataID, libprecicePath), Cint, (Ptr{Int8}, Cint), dataName, meshID)
     return id
 end
 
@@ -461,7 +483,7 @@ v1_id = setMeshVertex(mesh_id, [1,1,1])
 ```
 """
 function setMeshVertex(meshID::Integer, position::AbstractArray{Float64})
-    id::Integer = ccall((:precicec_setMeshVertex, "libprecice"), Cint, (Cint, Ref{Float64}), meshID, position)
+    id::Integer = ccall((:precicec_setMeshVertex, libprecicePath), Cint, (Cint, Ref{Float64}), meshID, position)
     return id
 end
 
@@ -504,7 +526,7 @@ positions = getMeshVertices(mesh_id, vertex_ids)
 ```
 """
 function getMeshVertices(meshID::Integer, size::Integer, ids::AbstractArray{Cint}, positions::AbstractArray{Float64})
-    ccall((:precicec_getMeshVertices, "libprecice"), Cvoid, (Cint, Cint, Ref{Cint}, Ref{Cdouble}), meshID, size, ids, positions)
+    ccall((:precicec_getMeshVertices, libprecicePath), Cvoid, (Cint, Cint, Ref{Cint}, Ref{Cdouble}), meshID, size, ids, positions)
 end
 
 
@@ -540,7 +562,7 @@ vertex_ids = setMeshVertices(mesh_id, 3, vertices)
 """
 function setMeshVertices(meshID::Integer, size::Integer, positions::AbstractArray{Float64})
     vertexIDs = Array{Int32, 1}(undef, size)
-    ccall((:precicec_setMeshVertices, "libprecice"), Cvoid, (Cint, Cint, Ref{Cdouble}, Ref{Cint}), meshID, size, positions, vertexIDs)
+    ccall((:precicec_setMeshVertices, libprecicePath), Cvoid, (Cint, Cint, Ref{Cdouble}, Ref{Cint}), meshID, size, positions, vertexIDs)
     return vertexIDs 
 end
 
@@ -553,7 +575,7 @@ Return the number of vertices of a mesh.
 
 """
 function getMeshVertexSize(meshID::Integer)::Integer
-    size::Integer = ccall((:precicec_getMeshVertexSize, "libprecice"), Cint, (Cint,), meshID)
+    size::Integer = ccall((:precicec_getMeshVertexSize, libprecicePath), Cint, (Cint,), meshID)
     return size
 end
 
@@ -590,7 +612,7 @@ vertex_ids = getMeshVertexIDsFromPositions(meshID, positions)
 ```
 """
 function getMeshVertexIDsFromPositions(meshID::Integer, size::Integer, positions::AbstractArray{Float64}, ids::AbstractArray{Cint})
-    ccall((:precicec_getMeshVertexIDsFromPositions, "libprecice"), Cvoid, (Cint, Cint, Ref{Cdouble}, Ref{Cint}), meshID, size, positions, ids)
+    ccall((:precicec_getMeshVertexIDsFromPositions, libprecicePath), Cvoid, (Cint, Cint, Ref{Cdouble}, Ref{Cint}), meshID, size, positions, ids)
 end
 
 
@@ -612,7 +634,7 @@ Previous calls:
 
 """
 function setMeshEdge(meshID::Integer, firstVertexID::Integer, secondVertexID::Integer)::Integer
-    edgeID::Integer = ccall((:precicec_setMeshEdge, "libprecice"), Cint, (Cint, Cint, Cint), meshID, firstVertexID, secondVertexID)
+    edgeID::Integer = ccall((:precicec_setMeshEdge, libprecicePath), Cint, (Cint, Cint, Cint), meshID, firstVertexID, secondVertexID)
     return edgeID
 end
 
@@ -635,7 +657,7 @@ Previous calls:
  - Edges with `first_edge_id`, `second_edge_id`, and `third_edge_id` were added to the mesh with the ID `meshID`
 """
 function setMeshTriangle(meshID::Integer, firstEdgeID::Integer, secondEdgeID::Integer, thirdEdgeID::Integer)
-    ccall((:precicec_setMeshTriangle, "libprecice"), Cvoid, (Cint, Cint, Cint, Cint), meshID, firstEdgeID, secondEdgeID, thirdEdgeID)
+    ccall((:precicec_setMeshTriangle, libprecicePath), Cvoid, (Cint, Cint, Cint, Cint), meshID, firstEdgeID, secondEdgeID, thirdEdgeID)
 end
 
 
@@ -662,7 +684,7 @@ Previous calls:
  - Edges with `firstVertexID`, `secondVertexID`, and `thirdEdgeID` were added to the mesh with the ID `meshID`
 """
 function setMeshTriangleWithEdges(meshID::Integer, firstEdgeID::Integer, secondEdgeID::Integer, thirdEdgeID::Integer)
-    ccall((:precicec_setMeshTriangleWithEdges, "libprecice"), Cvoid, (Cint, Cint, Cint, Cint), meshID, firstEdgeID, secondEdgeID, thirdEdgeID)
+    ccall((:precicec_setMeshTriangleWithEdges, libprecicePath), Cvoid, (Cint, Cint, Cint, Cint), meshID, firstEdgeID, secondEdgeID, thirdEdgeID)
 end
 
 
@@ -688,7 +710,7 @@ Previous calls:
     to the mesh with the ID `mesh_id`
 """
 function setMeshQuad(meshID::Integer, firstEdgeID::Integer, secondEdgeID::Integer, thirdEdgeID, fourthEdgeID::Integer)
-    ccall((:precicec_setMeshQuad, "libprecice"), Cvoid, (Cint, Cint, Cint, Cint, Cint), meshID, firstEdgeID, secondEdgeID, thirdEdgeID, fourthEdgeID)
+    ccall((:precicec_setMeshQuad, libprecicePath), Cvoid, (Cint, Cint, Cint, Cint, Cint), meshID, firstEdgeID, secondEdgeID, thirdEdgeID, fourthEdgeID)
 end
 
 
@@ -716,7 +738,7 @@ Previous calls:
     to the mesh with the ID `mesh_id`
 """
 function setMeshQuadWithEdges(meshID::Integer, firstEdgeID::Integer, secondEdgeID::Integer, thirdEdgeID::Integer)
-    ccall((:precicec_setMeshQuadWithEdges, "libprecice"), Cvoid, (Cint, Cint, Cint, Cint, Cint), meshID, firstEdgeID, secondEdgeID, thirdEdgeID, fourthEdgeID)
+    ccall((:precicec_setMeshQuadWithEdges, libprecicePath), Cvoid, (Cint, Cint, Cint, Cint, Cint), meshID, firstEdgeID, secondEdgeID, thirdEdgeID, fourthEdgeID)
 end
 
 
@@ -764,7 +786,7 @@ writeBlockVectorData(data_id, vertex_ids, values)
 ```
 """
 function writeBlockVectorData(dataID::Integer, size::Integer, valueIndices::AbstractArray{Cint}, values::AbstractArray{Float64})
-    ccall((:precicec_writeBlockVectorData, "libprecice"), Cvoid, (Cint, Cint, Ref{Cint}, Ref{Cdouble}), dataID, size, valueIndices, values)
+    ccall((:precicec_writeBlockVectorData, libprecicePath), Cvoid, (Cint, Cint, Ref{Cint}, Ref{Cdouble}), dataID, size, valueIndices, values)
 end
 
 
@@ -810,7 +832,7 @@ writeVectorData(data_id, vertex_id, value)
 ```
 """
 function writeVectorData(dataID::Integer, valueIndex::Integer, dataValue::AbstractArray{Float64})
-    ccall((:precicec_writeVectorData, "libprecice"), Cvoid, (Cint, Cint, Ref{Cdouble}), dataID, valueIndex, dataValue)
+    ccall((:precicec_writeVectorData, libprecicePath), Cvoid, (Cint, Cint, Ref{Cdouble}), dataID, valueIndex, dataValue)
 end
 
 # TODO same as above
@@ -846,7 +868,7 @@ writeBlockScalarData(data_id, vertex_ids, values)
 ```
 """
 function writeBlockScalarData(dataID::Integer, size::Integer, valueIndices::AbstractArray{Cint}, values::AbstractArray{Float64})
-    ccall((:precicec_writeBlockScalarData, "libprecice"), Cvoid, (Cint, Cint, Ref{Cint}, Ref{Cdouble}), dataID, size, valueIndices, values)
+    ccall((:precicec_writeBlockScalarData, libprecicePath), Cvoid, (Cint, Cint, Ref{Cint}, Ref{Cdouble}), dataID, size, valueIndices, values)
 end
 
 # TODO example is strange
@@ -878,7 +900,7 @@ writeScalarData(data_id, vertex_id, value)
 ```
 """
 function writeScalarData(dataID::Integer, valueIndex::Integer, dataValue::Float64)
-    ccall((:precicec_writeScalarData, "libprecice"), Cvoid, (Cint, Cint, Cdouble), dataID, valueIndex, dataValue)
+    ccall((:precicec_writeScalarData, libprecicePath), Cvoid, (Cint, Cint, Cdouble), dataID, valueIndex, dataValue)
 end
 
 # TODO: is the form correct?
@@ -922,7 +944,7 @@ values = readBlockVectorData(data_id, vertex_ids)
 ```
 """
 function readBlockVectorData(dataID::Integer, size::Integer, valueIndices::AbstractArray{Cint}, values::AbstractArray{Float64})
-    ccall((:precicec_readBlockVectorData, "libprecice"), Cvoid, (Cint, Cint, Ref{Cint}, Ref{Cdouble}), dataID, size, valueIndices, values)
+    ccall((:precicec_readBlockVectorData, libprecicePath), Cvoid, (Cint, Cint, Ref{Cint}, Ref{Cdouble}), dataID, size, valueIndices, values)
 end
 
 # TODO continuous block of memory?
@@ -961,7 +983,7 @@ value = readVectorData(data_id, vertex_id)
 ```
 """
 function readVectorData(dataID::Integer, valueIndex::Integer, dataValue::AbstractArray{Float64})
-    ccall((:precicec_readVectorData, "libprecice"), Cvoid, (Cint, Cint, Ref{Cdouble}), dataID, valueIndex, dataValue)
+    ccall((:precicec_readVectorData, libprecicePath), Cvoid, (Cint, Cint, Ref{Cdouble}), dataID, valueIndex, dataValue)
 end
 
 
@@ -995,7 +1017,7 @@ values = readBlockScalarData(data_id, vertex_ids)
 ```
 """
 function readBlockScalarData(dataID::Integer, size::Integer, valueIndices::AbstractArray{Cint}, values::AbstractArray{Float64})
-    ccall((:precicec_readScalarVectorData, "libprecice"), Cvoid, (Cint, Cint, Ref{Cint}, Ref{Cdouble}), dataID, size, valueIndices, values)
+    ccall((:precicec_readScalarVectorData, libprecicePath), Cvoid, (Cint, Cint, Ref{Cint}, Ref{Cdouble}), dataID, size, valueIndices, values)
 end
 
 
@@ -1025,7 +1047,7 @@ value = readScalarData(data_id, vertex_id)
 ```
 """
 function readScalarData(dataID::Integer, valueIndex::Integer, dataValue::AbstractArray{Float64})
-    ccall((:precicec_readScalarData, "libprecice"), Cvoid, (Cint, Cint, Ref{Cdouble}), dataID, valueIndex, dataValue)
+    ccall((:precicec_readScalarData, libprecicePath), Cvoid, (Cint, Cint, Ref{Cdouble}), dataID, valueIndex, dataValue)
 end
 
 
@@ -1039,7 +1061,7 @@ Return a semicolon-separated String containing:
  - the configuration of preCICE including MPI, PETSC, PYTHON
 """
 function getVersionInformation()
-    versionCstring = ccall((:precicec_getVersionInformation, "libprecice"), Cstring, ())
+    versionCstring = ccall((:precicec_getVersionInformation, libprecicePath), Cstring, ())
     return unsafe_string(versionCstring)
 end
 
@@ -1057,7 +1079,7 @@ Previous calls:
  - A mapping to [`fromMeshID`](@ref) was configured
 """
 function mapWriteDataFrom(fromMeshID::Integer)
-    ccall((:precicec_mapWriteDataFrom, "libprecice"), Cvoid, (Cint,), fromMeshID)
+    ccall((:precicec_mapWriteDataFrom, libprecicePath), Cvoid, (Cint,), fromMeshID)
 end
 
 
@@ -1075,7 +1097,7 @@ Previous calls:
  - A mapping to [`toMeshID`](@ref) was configured.
 """
 function mapReadDataTo(fromMeshID::Integer)
-    ccall((:precicec_mapReadDataTo, "libprecice"), Cvoid, (Cint,), fromMeshID)
+    ccall((:precicec_mapReadDataTo, libprecicePath), Cvoid, (Cint,), fromMeshID)
 end
 
 
@@ -1087,7 +1109,7 @@ Return the name of action for writing initial data.
 
 """
 function actionWriteInitialData()
-    msgCstring = ccall((:precicec_actionWriteInitialData, "libprecice"), Cstring, ())
+    msgCstring = ccall((:precicec_actionWriteInitialData, libprecicePath), Cstring, ())
     return unsafe_string(msgCstring)
 end
 
@@ -1099,7 +1121,7 @@ end
 Return name of action for writing iteration checkpoint.
 """
 function actionWriteIterationCheckpoint()
-    msgCstring = ccall((:precicec_actionWriteIterationCheckpoint, "libprecice"), Cstring, ())
+    msgCstring = ccall((:precicec_actionWriteIterationCheckpoint, libprecicePath), Cstring, ())
     return unsafe_string(msgCstring)
 end
 
@@ -1111,7 +1133,7 @@ end
 Return name of action for reading iteration checkpoint
 """
 function actionReadIterationCheckpoint()
-    msgCstring = ccall((:precicec_actionReadIterationCheckpoint, "libprecice"), Cstring, ())
+    msgCstring = ccall((:precicec_actionReadIterationCheckpoint, libprecicePath), Cstring, ())
     return unsafe_string(msgCstring)
 end
 


### PR DESCRIPTION
closes #10 

This PR enables a custom installation path for PreCICE. A lot had already been implemented, but in the documentation branch, this has now been moved to this branch.

The default path is set to `/usr/local/` in [PreCICE.jl](https://github.com/precice/julia-bindings/blob/ed4693fd675e9b8af072dcd4f0230ff7fa91a15b/src/PreCICE.jl#L16-L17), but when building the bindings a command will query the system for the location of `libprecice`.