### PR TITLE
Rework matrices from vectorised to matrix form

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "57fbd4af-5cc3-4712-aac0-6930e7658184"
 authors = ["preCICE <https://precice.org/> and contributors"]
 version = "0.1.0"
 
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
 [compat]
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -3,9 +3,6 @@ uuid = "57fbd4af-5cc3-4712-aac0-6930e7658184"
 authors = ["preCICE <https://precice.org/> and contributors"]
 version = "0.1.0"
 
-[deps]
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-
 [compat]
 julia = "1.6"
 

--- a/solverdummy/solverdummy.jl
+++ b/solverdummy/solverdummy.jl
@@ -36,12 +36,12 @@ numberOfVertices = 3
 readDataID  = PreCICE.getDataID(dataReadName, meshID)
 writeDataID = PreCICE.getDataID(dataWriteName, meshID)
 
-writeData = zeros(numberOfVertices * dimensions)
+writeData = zeros(numberOfVertices, dimensions)
 
-vertices = Array{Float64, 1}(undef, numberOfVertices * dimensions)
+vertices = Array{Float64, 2}(undef, numberOfVertices, dimensions)
 
 for i in 1:numberOfVertices, j in 1:dimensions
-        vertices[j + dimensions * (i-1)] = i
+        vertices[i,j] = i
 end
 
 vertexIDs = PreCICE.setMeshVertices(meshID, vertices)
@@ -49,7 +49,7 @@ vertexIDs = PreCICE.setMeshVertices(meshID, vertices)
 let # setting local scope for dt outside of the while loop
 
 dt = PreCICE.initialize()
-readData = zeros(numberOfVertices * dimensions)
+readData = zeros(numberOfVertices, dimensions)
 
 while PreCICE.isCouplingOngoing()
     
@@ -62,8 +62,8 @@ while PreCICE.isCouplingOngoing()
         readData = PreCICE.readBlockVectorData(readDataID, vertexIDs) 
     end
 
-    for i in 1:(numberOfVertices * dimensions)
-        writeData[i] = readData[i] + 1.0
+    for i in 1:numberOfVertices,j in 1:dimensions
+        writeData[i,j] = readData[i,j] + 1.0
     end
 
     if PreCICE.isWriteDataRequired(dt)

--- a/src/PreCICE.jl
+++ b/src/PreCICE.jl
@@ -778,7 +778,7 @@ writeBlockVectorData(data_id, vertex_ids, values)
 ```
 """
 function writeBlockVectorData(dataID::Integer, valueIndices::AbstractArray{Cint}, values::AbstractArray{Float64})
-    _size,dimensions = size(valueIndices)
+    _size,dimensions = size(values)
     @assert dimensions==getDimensions() "Dimensions of vector data in write_vector_data does not match with dimensions in problem definition. Provided dimensions: $dimensions, expected dimensions: $get_dimensions()"
 
     ccall((:precicec_writeBlockVectorData, libprecicePath), Cvoid, (Cint, Cint, Ref{Cint}, Ref{Cdouble}), dataID, _size, valueIndices, reshape(transpose(values),:))

--- a/src/PreCICE.jl
+++ b/src/PreCICE.jl
@@ -610,6 +610,8 @@ vertex_ids = getMeshVertexIDsFromPositions(meshID, positions)
 """
 function getMeshVertexIDsFromPositions(meshID::Integer, positions::AbstractArray{Float64})
     _size,dimensions = size(positions)
+    @assert dimensions==getDimensions() "Dimensions of vector data in write_vector_data does not match with dimensions in problem definition. Provided dimensions: $dimensions, expected dimensions: $get_dimensions()"
+
     ids = Array{Cint,1}(undef, _size)
     ccall((:precicec_getMeshVertexIDsFromPositions, libprecicePath), Cvoid, (Cint, Cint, Ref{Cdouble}, Ref{Cint}), meshID, _size, reshape(transpose(positions),:), ids)
     return ids
@@ -777,6 +779,8 @@ writeBlockVectorData(data_id, vertex_ids, values)
 """
 function writeBlockVectorData(dataID::Integer, valueIndices::AbstractArray{Cint}, values::AbstractArray{Float64})
     _size,dimensions = size(valueIndices)
+    @assert dimensions==getDimensions() "Dimensions of vector data in write_vector_data does not match with dimensions in problem definition. Provided dimensions: $dimensions, expected dimensions: $get_dimensions()"
+
     ccall((:precicec_writeBlockVectorData, libprecicePath), Cvoid, (Cint, Cint, Ref{Cint}, Ref{Cdouble}), dataID, _size, valueIndices, reshape(transpose(values),:))
 end
 


### PR DESCRIPTION
Closes #14 

In this PR the Matrices that were previously vectorised in the shape `(dx0,dy0,dx1,dy1,...)` get reworked to make use of Julia's matrix form `[dx0 dy0; dx1 dy1; ...]` to have the shape `[N x D]` where N = number of vertices and D = dimensions of geometry.